### PR TITLE
Disable minification.

### DIFF
--- a/rollup.config.js
+++ b/rollup.config.js
@@ -71,7 +71,7 @@ export default {
 
 		// If we're building for production (npm run build
 		// instead of npm run dev), minify
-		production && terser(),
+		// production && terser(), - we disable minification to enable debugging of the deployed game
 		json()
 	],
 	watch: {


### PR DESCRIPTION
The build had minification enabled. This made it extra difficult to debug the game when it wasn't working.